### PR TITLE
Ubuntu 22.04 compatibility

### DIFF
--- a/src/check_systemd_service
+++ b/src/check_systemd_service
@@ -26,7 +26,7 @@ class Service(object):
                 continue
 
             key, value = line.split('=', 1)
-            if value and key.endswith('Timestamp'):
+            if value and key.endswith('Timestamp') and value != 'n/a':
                 value = datetime.strptime(value, '%a %Y-%m-%d %H:%M:%S %Z')
             info[key] = value
 


### PR DESCRIPTION
After an upgrade I noticed several values with n/a in e.g. WatchdogTimestamp which caused this script to fail on datetime.strptime()
Since they are not used by this script I now just ignore them.
